### PR TITLE
Add button action for reserve and cancel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 :root {
-  --main-color:  #00A3B8;
+  --main-color: #00a3b8;
   --text-color: #fff;
 }
 
@@ -100,7 +100,7 @@ h1 {
 
 .cancel-btn {
   max-width: 120px;
-  background-color:  #e0e0e0;
+  background-color: #e0e0e0;
   border: 1px solid #cfcfcf;
   border-radius: 3px;
   color: #918e8e;

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,8 @@
+:root {
+  --main-color:  #00A3B8;
+  --text-color: #fff;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -38,7 +43,7 @@ h1 {
   margin: 22px;
   padding: 10px;
   font-size: 18px;
-  color: #5f81f1;
+  color: var(--main-color);
   cursor: pointer;
 }
 
@@ -64,12 +69,41 @@ h1 {
   flex-direction: column;
 }
 
+.rocket-des {
+  font-size: 16px;
+  margin: 10px 0;
+}
+
 .reserve-btn {
   max-width: 120px;
-  background-color: #5f81f1;
+  background-color: var(--main-color);
   border: none;
   border-radius: 3px;
-  color: white;
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 12px;
+  margin: 4px 2px;
+  padding: 4px 2px;
+  cursor: pointer;
+}
+
+.reserved-r {
+  color: #fff;
+  background-color: var(--main-color);
+  border-radius: 10px;
+  margin: 0 8px 0 0;
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
+.cancel-btn {
+  max-width: 120px;
+  background-color:  #e0e0e0;
+  border: 1px solid #cfcfcf;
+  border-radius: 3px;
+  color: #918e8e;
   text-align: center;
   text-decoration: none;
   display: inline-block;

--- a/src/Components/RocketPage.js
+++ b/src/Components/RocketPage.js
@@ -1,15 +1,24 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getRockets } from '../Redux/Rockets/rockets';
+import { getRockets, reserveRockets, cancelRockets } from '../Redux/Rockets/rockets';
 
 export default function Rocket() {
   const dispatch = useDispatch();
   const rocketNum = useSelector((state) => state.rockets);
+  const reserveHandler = (id) => {
+    dispatch(reserveRockets(id));
+  };
+  const cancelHandler = (id) => {
+    dispatch(cancelRockets(id));
+  };
+
   useEffect(() => {
     if (rocketNum.length === 0) {
       dispatch(getRockets());
     }
   }, []);
+
+  let reserved = null;
 
   return (
     <div className="rocket-c">
@@ -21,10 +30,26 @@ export default function Rocket() {
           <div className="rocket-info">
             <li><h3>{rocket.name}</h3></li>
             <p className="rocket-des">
-              {rocket.reserved && (<span>Reserved</span>)}
+              {rocket.reserved && (<span className="reserved-r">Reserved</span>)}
               {rocket.description}
             </p>
-            <button className="reserve-btn" type="button">Reserve Rocket</button>
+            <button
+              type="button"
+              className={!rocket.reserved === true ? 'reserve-btn' : 'cancel-btn'}
+              onClick={
+              () => {
+                reserved = rocket.reserved;
+                if (!reserved) {
+                  reserveHandler(rocket.id);
+                } else {
+                  cancelHandler(rocket.id);
+                }
+              }
+            }
+            >
+              {!rocket.reserved === true ? 'Reserved Rocket' : 'Cancel Reservation'}
+
+            </button>
           </div>
         </ul>
       ))}

--- a/src/Redux/Rockets/rockets.js
+++ b/src/Redux/Rockets/rockets.js
@@ -1,6 +1,8 @@
 import spaceXAPI from '../../Components/RocketApi';
 
 const GET_ROCKETS = 'spaceX/rockets/GET_ROCKETS';
+const RESERVE_ROCKETS = 'spaceX/rockets/RESERVE_ROCKETS';
+const CANCEL_ROCKETS = 'spaceX/rockets/CANCEL_ROCKETS';
 
 const initialState = [];
 // Reducers
@@ -8,6 +10,20 @@ const rocketReducer = (state = initialState, action) => {
   switch (action.type) {
     case GET_ROCKETS:
       return action.payload;
+    case RESERVE_ROCKETS: {
+      const newState = state.map((rocket) => (rocket.id !== action.payload
+        ? rocket
+        : { ...rocket, reserved: true }));
+
+      return newState;
+    }
+    case CANCEL_ROCKETS: {
+      const newState = state.map((rocket) => (rocket.id !== action.payload
+        ? rocket
+        : { ...rocket, reserved: false }));
+
+      return newState;
+    }
     default:
       return state;
   }
@@ -31,5 +47,15 @@ export const getRockets = () => (dispatch) => {
     ));
   });
 };
+
+export const reserveRockets = (payload) => ({
+  type: RESERVE_ROCKETS,
+  payload,
+});
+
+export const cancelRockets = (payload) => ({
+  type: CANCEL_ROCKETS,
+  payload,
+});
 
 export default rocketReducer;


### PR DESCRIPTION
- Added actions and reducers for booking rockets by adding the key-value `reserved: true` &` reserved: false`
-  Reserved rockets are showing the "**Reserved**" badge and "**Cancel reservation**" button instead of the default "Reserve rocket" (as per design).
- Used conditional rendering syntax 
```
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```